### PR TITLE
Add callback_stdout and verbosity option and fix nits

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ You can of course edit the file with a text editor, too.
 
 ### Logging
 
-If you want to have the validation results logged into a file you can use the `--log-path <local file path>` option. Instead of just outputting the validation results on stdout it will log the results to the given log file path. If the file already exists the entries will be appended to the file, otherwise the file will be created. 
+If you want to have the validation results logged into a file you can use the `--log-path <local file path>` option. Instead of just outputting the validation results on stdout it will log the results to the given log file path. If the file already exists the entries will be appended to the file, otherwise the file will be created.
 
 
 ### Options
@@ -134,7 +134,7 @@ Here's a step to step guide to test a new validation in container-validations:
 
 For example if you want to test a new validation that runs on the host from
 which you're running container-validations your inventory file should look
-something like this: 
+something like this:
 
 ```
 ---
@@ -163,7 +163,7 @@ Please note that you can test all connections in your inventory file:
 
 Usually you want to use a local repository for development. You can use the
 `--repository` option to define a path to a local repository (remember you can
-store the value in a config file): 
+store the value in a config file):
 
 ```Bash
 ./validations.py --repository /home/stack/tripleo-validations --validations my-validation
@@ -201,7 +201,7 @@ In order to build it on your own, you can run:
 In order to manually run the container, you can run:
 ```Bash
 (podman|docker) run --rm -e "INVENTORY=localhost," \
-  -e "VALIDATIONS=dns,no-op' \
+  -e "VALIDATIONS=dns,no-op" \
   -v $(pwd)/.ssh/id_rsa:/home/my-user/.ssh/id_rsa \
   validations
 ```
@@ -223,4 +223,3 @@ Set the keyfile manually (usually /home/<current user>/.ssh/id_rsa).
 
 Install additional packages into your container image if they're needed by
 custom validations.
-

--- a/init.sh
+++ b/init.sh
@@ -5,10 +5,7 @@ INV=${INVENTORY:="/root/inventory.yaml"}
 VALS=${VALIDATIONS:=""}
 
 # Set logging env var to file mounted into the container.
-if [ -f "/root/validations.log" ]; then
-  export ANSIBLE_LOG_PATH="/root/validations.log"
-fi
-
+export ANSIBLE_LOG_PATH="/root/validations.log"
 
 # Run the inventory ping test
 if [ "${ACTION}" == "inventory_ping" ]; then
@@ -26,11 +23,11 @@ if [[ "${ACTION}" =~ ^(run|list)$ ]]; then
     val_dir=$(basename "${REPO}" .git)
   fi
   if [ "${GROUP}" != "" ]; then
-    VALS_FROM_REPO=$(/usr/bin/python3 listing.py ${val_dir} --group ${GROUP})
+    VALS_FROM_REPO=$(/usr/bin/python3 /root/listing.py ${val_dir} --group ${GROUP})
   elif [ "${HOST}" != "" ]; then
-    VALS_FROM_REPO=$(/usr/bin/python3 listing.py ${val_dir} --host ${HOST})
+    VALS_FROM_REPO=$(/usr/bin/python3 /root/listing.py ${val_dir} --host ${HOST})
   else
-    VALS_FROM_REPO=$(/usr/bin/python3 listing.py ${val_dir})
+    VALS_FROM_REPO=$(/usr/bin/python3 /root/listing.py ${val_dir})
   fi
 fi
 
@@ -46,7 +43,7 @@ if [ "${ACTION}" == "list" ]; then
   echo ${VALS_FROM_REPO}
 fi
 
-# Run a list of validations 
+# Run a list of validations
 if [ "${ACTION}" == "run" ]; then
 
   cd "${val_dir}"

--- a/validation.py
+++ b/validation.py
@@ -107,8 +107,9 @@ class RunValidations:
         config.set('Validations', 'group', self.__args['group'])
         config.set('Validations', 'host', self.__args['host'])
         config.set('Validations', 'log_path', self.__args['log_path'])
-        config.set('Validations', 'ansible_callback',
-                   self.__args['ansible_callback'])
+        if self.__args.get('ansible_callback'):
+            config.set('Validations', 'ansible_callback',
+                       self.__args['ansible_callback'])
 
         if self.__args.get('create_config'):
             print('Generating config file')


### PR DESCRIPTION
* Fix nits in documentation,
* Move listing.py and init.sh under /root in the container
  to be consistent with the location of the tripleo-validations
  location
* Add option to overide the validation callback stdout in order to
  get something with much details if wanted or more verbose like
  the ansible default ones.
* Improve de --debug option to add verbosity level at 4.
  For now hardcoded to4, but can be set with an option.
* Provides the /root/validations.log file by default in init.sh
  The test -f with bash cause that if no file exist, the output is not
  logged.